### PR TITLE
Modify class init to allow session_id and instance to be passed in

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,7 @@ Usage
 -----
 To use API classes one needs to create a session first by instantiating SfdcSession class and passing login details to the constructor.
 
+One method is to pass in the username, password, and token:
 .. code-block:: python
 
     from sfdclib import SfdcSession
@@ -19,6 +20,22 @@ To use API classes one needs to create a session first by instantiating SfdcSess
         'is_sandbox': True
     )
     s.login()
+
+A second method, if you've already logged in elsewhere, is to pass in the instance and session_id. This method does not require calling login().
+.. code-block:: python
+
+    from sfdclib import SfdcSession
+
+    s = SfdcSession(
+        'username': None,
+        'password': None,
+        'token': None,
+        'is_sandbox': True,
+        'api_version': "37.0",
+        'session_id': 'thiswillbeaverylongstringofcharactersincludinglettersspacesandsymbols',
+        'instance': 'custom-sf-site.my'
+    )
+    # Notice we are not calling the login() method for this example.
 
 Then create an instance of corresponding API class passing session object.
 

--- a/README.rst
+++ b/README.rst
@@ -27,11 +27,6 @@ A second method, if you've already logged in elsewhere, is to pass in the instan
     from sfdclib import SfdcSession
 
     s = SfdcSession(
-        'username': None,
-        'password': None,
-        'token': None,
-        'is_sandbox': True,
-        'api_version': "37.0",
         'session_id': 'thiswillbeaverylongstringofcharactersincludinglettersspacesandsymbols',
         'instance': 'custom-sf-site.my'
     )

--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,7 @@ Usage
 To use API classes one needs to create a session first by instantiating SfdcSession class and passing login details to the constructor.
 
 One method is to pass in the username, password, and token:
+
 .. code-block:: python
 
     from sfdclib import SfdcSession
@@ -22,6 +23,7 @@ One method is to pass in the username, password, and token:
     s.login()
 
 A second method, if you've already logged in elsewhere, is to pass in the instance and session_id. This method does not require calling login().
+
 .. code-block:: python
 
     from sfdclib import SfdcSession

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name='sfdclib',
-    version='0.2.15',
+    version='0.2.16',
     author='Andrey Shevtsov',
     author_email='ashevtsov@rbauction.com',
     packages=['sfdclib'],

--- a/sfdclib/session.py
+++ b/sfdclib/session.py
@@ -28,15 +28,16 @@ xmlns:env='http://schemas.xmlsoap.org/soap/envelope/'>
 
     def __init__(
             self, username=None, password=None, token=None,
-            is_sandbox=False, api_version=_DEFAULT_API_VERSION):
+            is_sandbox=False, api_version=_DEFAULT_API_VERSION,
+            session_id=None, instance=None):
         super(SfdcSession, self).__init__()
         self._username = username
         self._password = password
         self._token = token
         self._is_sandbox = is_sandbox
         self._api_version = api_version
-        self._session_id = None
-        self._instance = None
+        self._session_id = session_id
+        self._instance = instance
 
     def login(self):
         url = self.construct_url(self.get_soap_api_uri())

--- a/sfdclib/session.py
+++ b/sfdclib/session.py
@@ -29,15 +29,15 @@ xmlns:env='http://schemas.xmlsoap.org/soap/envelope/'>
     def __init__(
             self, username=None, password=None, token=None,
             is_sandbox=False, api_version=_DEFAULT_API_VERSION,
-            session_id=None, instance=None):
+            **kwargs):
         super(SfdcSession, self).__init__()
         self._username = username
         self._password = password
         self._token = token
         self._is_sandbox = is_sandbox
         self._api_version = api_version
-        self._session_id = session_id
-        self._instance = instance
+        self._session_id = kwargs.get("session_id", None)
+        self._instance = kwargs.get("instance", None)
 
     def login(self):
         url = self.construct_url(self.get_soap_api_uri())


### PR DESCRIPTION
Here's a pull request for a new feature. This allows you to pass in a session_id and instance, for the use case where (like me) you are authenticating before sfdclib is used.

The README.rst has been updated, but here is the way this works now:

```python
s = SfdcSession(
    'session_id': 'thiswillbeaverylongstringofcharactersincludinglettersspacesandsymbols',
    'instance': 'custom-sf-site.my'
)
```

Note that you do NOT call login() for this method.
