### PR TITLE
Python 2.7 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name='sfdclib',
-    version='0.2.16',
+    version='0.2.17',
     author='Andrey Shevtsov',
     author_email='ashevtsov@rbauction.com',
     packages=['sfdclib'],

--- a/sfdclib/rest.py
+++ b/sfdclib/rest.py
@@ -3,7 +3,7 @@ import json
 try:
     from urllib.parse import urlencode
 except ImportError:
-    from urlparse import urlparse
+    from urlparse import urlencode
 
 
 class SfdcRestApi:

--- a/sfdclib/rest.py
+++ b/sfdclib/rest.py
@@ -1,6 +1,9 @@
 """ Class to work with Salesforce REST API """
 import json
-from urllib.parse import urlencode
+try:
+    from urllib.parse import urlencode
+except ImportError:
+    from urlparse import urlparse
 
 
 class SfdcRestApi:

--- a/sfdclib/tooling.py
+++ b/sfdclib/tooling.py
@@ -3,7 +3,7 @@ import json
 try:
     from urllib.parse import urlencode
 except ImportError:
-    from urlparse import urlparse
+    from urlparse import urlencode
 
 
 class SfdcToolingApi():

--- a/sfdclib/tooling.py
+++ b/sfdclib/tooling.py
@@ -1,6 +1,9 @@
 ''' Class to work with Salesforce Tooling API '''
 import json
-from urllib.parse import urlencode
+try:
+    from urllib.parse import urlencode
+except ImportError:
+    from urlparse import urlparse
 
 
 class SfdcToolingApi():


### PR DESCRIPTION
Changed the import statements for urllib.parse to a try/except, with the except instead importing the Python 2.7 urlparse module.

This seems to be the recommended method I've read; example:
http://python3porting.com/noconv.html

I haven't found any other issues with the code on a Python 2.7 interpreter in my testing so far.
