### PR TITLE
Fix import for urlencode

### DIFF
--- a/sfdclib/rest.py
+++ b/sfdclib/rest.py
@@ -3,7 +3,7 @@ import json
 try:
     from urllib.parse import urlencode
 except ImportError:
-    from urlparse import urlencode
+    from urllib import urlencode
 
 
 class SfdcRestApi:

--- a/sfdclib/tooling.py
+++ b/sfdclib/tooling.py
@@ -3,7 +3,7 @@ import json
 try:
     from urllib.parse import urlencode
 except ImportError:
-    from urlparse import urlencode
+    from urllib import urlencode
 
 
 class SfdcToolingApi():


### PR DESCRIPTION
The last fix I made for the import in rest.py and tooling.py was actually incorrect. I've corrected those with these changes.
