### PR TITLE
Adding support for describe() calls from the Salesforce Metadata API

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,7 @@ SfdcMetadataApi
 | **check_retrieve_status(id)** - retrieves retrieve call status. returns 3-tuple containing state, state detail and warning/error messages
 | **retrieve_zip(id)** - retrieves resulting ZIP file for the specified Id of retrieve call. returns 4-tuple containing state, state detail, warning/error messages and ZIP file
 | **describe()** - retrieves metadata objects from Salesforce
+| **list_metadata(objects)() - given a list of objects, returns their metadata details
 |
 
 SfdcToolingApi

--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,7 @@ SfdcMetadataApi
 | **retrieve(options)** - submits retrieve request
 | **check_retrieve_status(id)** - retrieves retrieve call status. returns 3-tuple containing state, state detail and warning/error messages
 | **retrieve_zip(id)** - retrieves resulting ZIP file for the specified Id of retrieve call. returns 4-tuple containing state, state detail, warning/error messages and ZIP file
+| **describe()** - retrieves metadata objects from Salesforce
 |
 
 SfdcToolingApi

--- a/sfdclib/__init__.py
+++ b/sfdclib/__init__.py
@@ -23,3 +23,7 @@ from sfdclib.bulk import (
 from sfdclib.rest import (
     SfdcRestApi
 )
+
+from sfdclib.soap import (
+    SfdcSoapApi
+)

--- a/sfdclib/messages.py
+++ b/sfdclib/messages.py
@@ -132,3 +132,24 @@ LIST_METADATA_MSG = """
    </soapenv:Body>
 </soapenv:Envelope>
 """
+
+DESCRIBE_SOBJECT_MSG = """
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:enterprise.soap.sforce.com">
+   <soapenv:Header>>
+      <urn:PackageVersionHeader>
+         <urn:packageVersions>
+            <urn:majorNumber>{majorNumber}</urn:majorNumber>
+            <urn:minorNumber>{minorNumber}</urn:minorNumber>
+         </urn:packageVersions>
+      </urn:PackageVersionHeader>
+      <urn:SessionHeader>
+         <urn:sessionId>{sessionId}</urn:sessionId>
+      </urn:SessionHeader>
+   </soapenv:Header>
+   <soapenv:Body>
+      <urn:describeSObject>
+         <urn:sObjectType>{sobjectName}</urn:sObjectType>
+      </urn:describeSObject>
+   </soapenv:Body>
+</soapenv:Envelope>
+"""

--- a/sfdclib/messages.py
+++ b/sfdclib/messages.py
@@ -93,7 +93,7 @@ xmlns:met="http://soap.sforce.com/2006/04/metadata">
    </soapenv:Body>
 </soapenv:Envelope>"""
 
-GET_METADATA_MSG = """
+DESCRIBE_METADATA_MSG = """
 <soapenv:Envelope
    xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
    xmlns:met="http://soap.sforce.com/2006/04/metadata"

--- a/sfdclib/messages.py
+++ b/sfdclib/messages.py
@@ -92,3 +92,24 @@ xmlns:met="http://soap.sforce.com/2006/04/metadata">
       </met:checkRetrieveStatus>
    </soapenv:Body>
 </soapenv:Envelope>"""
+
+GET_METADATA_MSG = """
+<soapenv:Envelope
+   xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+   xmlns:met="http://soap.sforce.com/2006/04/metadata"
+>
+   <soapenv:Header>
+      <met:CallOptions>
+         <met:client>{client}</met:client>
+      </met:CallOptions>
+      <met:SessionHeader>
+         <met:sessionId>{sessionId}</met:sessionId>
+      </met:SessionHeader>
+   </soapenv:Header>
+   <soapenv:Body>
+      <met:describeMetadata>
+         <met:asOfVersion>{apiVersion}</met:asOfVersion>
+      </met:describeMetadata>
+   </soapenv:Body>
+</soapenv:Envelope>
+"""

--- a/sfdclib/messages.py
+++ b/sfdclib/messages.py
@@ -113,3 +113,22 @@ DESCRIBE_METADATA_MSG = """
    </soapenv:Body>
 </soapenv:Envelope>
 """
+
+LIST_METADATA_MSG = """
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:met="http://soap.sforce.com/2006/04/metadata">
+   <soapenv:Header>
+      <met:CallOptions>
+         <met:client>{client}</met:client>
+      </met:CallOptions>
+      <met:SessionHeader>
+         <met:sessionId>{sessionId}</met:sessionId>
+      </met:SessionHeader>
+   </soapenv:Header>
+   <soapenv:Body>
+      <met:listMetadata>
+         {queries}
+         <met:asOfVersion>{apiVersion}</met:asOfVersion>
+      </met:listMetadata>
+   </soapenv:Body>
+</soapenv:Envelope>
+"""

--- a/sfdclib/metadata.py
+++ b/sfdclib/metadata.py
@@ -1,4 +1,5 @@
 """ Class to work with Salesforce Metadata API """
+from datetime import datetime
 from base64 import b64encode, b64decode
 from xml.etree import ElementTree as ET
 
@@ -341,10 +342,15 @@ class SfdcMetadataApi:
         for metadata_object in metadata_objects:
             file_name = metadata_object.find('mt:fileName', self._XML_NAMESPACES)
             xml_name = metadata_object.find('mt:fullName', self._XML_NAMESPACES)
+            last_modified = metadata_object.find('mt:lastModifiedDate', self._XML_NAMESPACES)
+
             if file_name is None and xml_name is None:
                 continue
-            metadata_objects_list.append({
+            temp = {
                 "file_name": file_name.text if file_name is not None else "",
                 "xml_name": xml_name.text if xml_name is not None else "",
-            })
+            }
+            if last_modified and len(last_modified.text) > 0:
+                temp["last_modified"] = datetime.strptime(last_modified.text, "%Y-%m-%dT%H:%M:%S")
+            metadata_objects_list.append(temp)
         return metadata_objects_list

--- a/sfdclib/metadata.py
+++ b/sfdclib/metadata.py
@@ -259,7 +259,7 @@ class SfdcMetadataApi:
             'apiVersion': self._session.get_api_version()
         }
 
-        request = msg.GET_METADATA_MSG.format(**attributes)
+        request = msg.DESCRIBE_METADATA_MSG.format(**attributes)
 
         headers = {'Content-type': 'text/xml', 'SOAPAction': 'describeMetadata'}
         res = self._session.post(self._get_api_url(), headers=headers, data=request)

--- a/sfdclib/soap.py
+++ b/sfdclib/soap.py
@@ -1,0 +1,52 @@
+"""Class to work with the Salesforce SOAP API.
+"""
+
+from base64 import b64encode, b64decode
+from xml.etree import ElementTree as ET
+
+import sfdclib.messages as msg
+
+
+class SfdcSoapApi(object):
+    """Class to work with the Salesforce SOAP API.
+    """
+    _SOAP_API_BASE_URI = "/services/Soap/c/{version}"
+    _XML_NAMESPACES = {
+        'soapenv': 'http://schemas.xmlsoap.org/soap/envelope/',
+        'ep': 'urn:enterprise.soap.sforce.com'
+    }
+
+    def __init__(self, session):
+        if not session.is_connected():
+            raise Exception("Session must be connected prior to instantiating this class")
+        self._session = session
+        self._deploy_zip = None
+
+    def _get_api_url(self):
+        return "%s%s" % (
+            self._session.get_server_url(),
+            self._SOAP_API_BASE_URI.format(**{'version': self._session.get_api_version()}))
+
+    def describe_sobject_type(self, sobject_name):
+        """Gets details for an object through the describeSObjec SOAP API.
+
+        :param sobject_name: The name of the object
+        """
+        version_string = str(self._session.get_api_version())
+        attributes = {
+            'sessionId': self._session.get_session_id(),
+            'majorNumber': version_string.split(".")[0],
+            'minorNumber': version_string.split(".")[1],
+            'sobjectName': sobject_name
+        }
+
+        request = msg.DESCRIBE_SOBJECT_MSG.format(**attributes)
+        headers = {'Content-type': 'text/xml', 'SOAPAction': 'describeSObject'}
+        res = self._session.post(self._get_api_url(), headers=headers, data=request)
+        if res.status_code != 200:
+            raise Exception(
+                "Request failed with %d code and error [%s]" %
+                (res.status_code, res.text))
+
+        root = ET.fromstring(res.text)
+        return root


### PR DESCRIPTION
Added a describe() method to SfdcMetadataApi which performs the
describeMetadatac SOAP request and returns a list of dicts containing the
parsed response.