### PR TITLE
Fix for encoding issue

### DIFF
--- a/sfdclib/session.py
+++ b/sfdclib/session.py
@@ -47,7 +47,7 @@ xmlns:env='http://schemas.xmlsoap.org/soap/envelope/'>
             password += self._token
         data = SfdcSession._LOGIN_TMPL.format(**{'username': self._username, 'password': password})
         r = self.post(url, headers=headers, data=data)
-        root = ET.fromstring(r.text)
+        root = ET.fromstring(r.text.encode('utf8', 'ignore'))
         if root.find('soapenv:Body/soapenv:Fault', SfdcSession._XML_NAMESPACES):
             raise Exception("Could not log in. Code: %s Message: %s" % (
                 root.find('soapenv:Body/soapenv:Fault/faultcode', SfdcSession._XML_NAMESPACES).text,


### PR DESCRIPTION
I was seeing an issue with the the currency symbol £ which was due to an encoding issue from the response of the login call.

The error I was seeing was 
Traceback (most recent call last):
    session.login()
  File "~/Library/Python/2.7/lib/python/site-packages/sfdclib/session.py", line 51, in login
    root = ET.fromstring(r.text)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/xml/etree/ElementTree.py", line 1300, in XML
    parser.feed(text)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/xml/etree/ElementTree.py", line 1640, in feed
    self._parser.Parse(data, 0)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xa3' in position 807: ordinal not in range(128)